### PR TITLE
Qualifie URLs.

### DIFF
--- a/dataset
+++ b/dataset
@@ -1423,7 +1423,7 @@ http://znmeb.github.com
 http://zorbash.github.com
 http://zwq.me
 http://zx1986.github.com
-http:kiikoo.github.com
+http://kiikoo.github.com
 https://0x41.no/
 https://5minutenpause.com/
 https://about.zoosk.com/en/engineering-blog/
@@ -2133,7 +2133,7 @@ http://mattycollins.com.au
 http://helentran.com
 http://linshuyang.com/
 http://silky.github.io/quantum-lunch/
-martinthoma.github.io
+http://martinthoma.github.io
 http://cloudcmd.io
 http://blog.cloudcmd.io/
 http://ioscowboy.com/


### PR DESCRIPTION
This updates `martinthoma.github.io` to add a `http://` prefix,
and corrects `http:kiikoo.github.com` too.

This closes #8.
